### PR TITLE
Update function getUrlForAppName URI for 'routes'

### DIFF
--- a/bash/scripts/curl_helper_funcs.sh
+++ b/bash/scripts/curl_helper_funcs.sh
@@ -706,7 +706,7 @@ function getUrlForAppName() {
   __validate_num_arguments 3 $# "\"curl_helper_funcs:getUrlForAppName\" expected in order: Name of Predix Application, variable name to store the URL, protocol  " "$logDir"
 
   local _result=$2
-  local _host=$(px app $1 | grep urls | awk -F" " '{print $2}');
+  local _host=$(px app $1 | grep routes | awk -F" " '{print $2}');
   local _url
   if [ -z "$_host" ]; then
     __error_exit "There was an error getting App URI for: $1" "$logDir"


### PR DESCRIPTION
Following the next guide on MAC (Sierra), We are getting an error describe below. 

Guide:
https://www.predix.io/resources/tutorials/tutorial-details.html?tutorial_id=2106&tag=All%20Guides&journey=All%20Guides

Error:
There was an error getting App URI for: fz-rmd-datasource /Users/..../appref/rmd-ref-app/predix-scripts/log

Solution:
The parse line looks for 'URI' but 'px app' command returns 'routes' instead.